### PR TITLE
P4-713 - fix remaining subdir issues

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -161,7 +161,7 @@ services:
       - 8091:8091
     networks:
       - pro-network
-    command: ["mailroom", "-redis=redis://redis:${REDIS_PORT}/15", "-db=${DATABASE_URL}","-s3-media-bucket=${AWS_STORAGE_BUCKET_NAME}","-aws-access-key-id=${AWS_ACCESS_KEY_ID}", "-aws-secret-access-key=${AWS_SECRET_ACCESS_KEY}", "-fcm-key=${FCM_API_KEY}", "-elastic=${ELASTICSEARCH_URL}"]
+    command: ["mailroom", "-redis=redis://redis:${REDIS_PORT}/15", "-db=${DATABASE_URL}","-s3-media-bucket=${AWS_STORAGE_BUCKET_NAME}","-aws-access-key-id=${AWS_ACCESS_KEY_ID}", "-aws-secret-access-key=${AWS_SECRET_ACCESS_KEY}", "-fcm-key=${FCM_API_KEY}", "-elastic=${ELASTICSEARCH_URL}", "-address=mailroom"]
   elasticsearch:
     image: elasticsearch:6.5.4
     restart: always

--- a/nginx.conf
+++ b/nginx.conf
@@ -40,7 +40,7 @@ http {
         location ~ (.*)/flow/simulate/(.*)$ {
             rewrite (.*)/flow/simulate/(.*) /flow/simulate/$2;
             proxy_set_header Host $http_host;
-            proxy_pass http://engage:8000/flow/simulate/$2;
+            proxy_pass http://engage:8000$1/flow/simulate/$2;
             proxy_set_header X-Forwarded-Path $request_uri;
             proxy_pass_request_headers on;
             break;


### PR DESCRIPTION
Flows stopped working due to an issue with the mailroom address missing. Also updated nginx.conf to properly redirect to the mailroom service.

With the `SUB_DIR` var configured in the docker-compose.yml file:
1. Open a valid flow. ex: /some_sub_dir/flow/editor/7739e828-85ba-49a5-ac3c-07fdd7697950/  and then click "Run in simulator"
2.  You should be prompted with the flows starting message.

With the `SUB_DIR` var disabled in the docker-compose.yml file:
1. Open a valid flow. ex: /flow/editor/7739e828-85ba-49a5-ac3c-07fdd7697950/  and then click "Run in simulator"
2.  You should be prompted with the flows starting message.

In both examples verify that /engage/flow/simulate/[id]/ AND /flow/simulate/[id]/ return http status code `200` (With Developer tools . network tab open, click the refresh button on the Flow Simulator)


