### PR TITLE
PULSE-7079 - APK media URL not being served under the subdir of Engag…

### DIFF
--- a/settings-engage.py
+++ b/settings-engage.py
@@ -17,6 +17,9 @@ from django.urls import base
 AWS_QUERYSTRING_EXPIRE = '157784630'
 SUB_DIR = env('SUB_DIR', required=False) 
 
+if SUB_DIR is not None and len(SUB_DIR) > 0:
+    MEDIA_URL = "{}{}".format(SUB_DIR, MEDIA_URL)
+
 STORAGE_URL = "https://"+AWS_BUCKET_DOMAIN
 MAILROOM_URL=env('MAILROOM_URL', 'http://localhost:8000')
 

--- a/settings-generic.py
+++ b/settings-generic.py
@@ -17,6 +17,9 @@ from django.urls import base
 AWS_QUERYSTRING_EXPIRE = '157784630'
 SUB_DIR = env('SUB_DIR', required=False) 
 
+if SUB_DIR is not None and len(SUB_DIR) > 0:
+    MEDIA_URL = "{}{}".format(SUB_DIR, MEDIA_URL)
+
 STORAGE_URL = "https://"+AWS_BUCKET_DOMAIN
 MAILROOM_URL=env('MAILROOM_URL', 'http://localhost:8000')
 

--- a/settings.py
+++ b/settings.py
@@ -17,6 +17,9 @@ from django.urls import base
 AWS_QUERYSTRING_EXPIRE = '157784630'
 SUB_DIR = env('SUB_DIR', required=False) 
 
+if SUB_DIR is not None and len(SUB_DIR) > 0:
+    MEDIA_URL = "{}{}".format(SUB_DIR, MEDIA_URL)
+
 STORAGE_URL = "https://"+AWS_BUCKET_DOMAIN
 MAILROOM_URL=env('MAILROOM_URL', 'http://localhost:8000')
 


### PR DESCRIPTION
…e, If the subdir is being used the media URL should also use the subdir

**Static review should suffice however for** Testing:
- In the settings.py or in .env files configure the SUB_DIR variable to SUB_DIR = "engage". 
- Standup a RP-docker instance and navigate to /apk/.
- Upload an apk file.
- The path to the apk file should be: http://localhost:[PORT]/engage/media/apks/[filename].apk
- Removing the SUB_DIR var should result in the apk path being:  http://localhost:[PORT]/media/apks/[filename].apk