### PR TITLE
Modify the `Flow Start` styling to be a lot more noticeable

### DIFF
--- a/customizations/engage/static/brands/engage/less/style.less
+++ b/customizations/engage/static/brands/engage/less/style.less
@@ -68,16 +68,17 @@ a.logo {
 #flow {
   .node {
     .flow-start {
-      font-size: 1.4em;
+      font-size: small;
       margin-top: -2em;
       width: auto;
       min-width: 170px;
-      padding: 6px 15px;
-      background-color: yellowgreen;
+      padding: 2px;
+      background-color: @color-primary;
       position: absolute;
       text-align: center;
-      color: royalblue;
-      font-weight: bolder;
+      color: white;
+      font-weight: bold;
+      font-variant-caps: all-small-caps;
     }
   }
 }

--- a/customizations/engage/static/brands/engage/less/style.less
+++ b/customizations/engage/static/brands/engage/less/style.less
@@ -64,3 +64,19 @@ a.logo {
   background-image: -webkit-linear-gradient(top, #4d8ac1, #3f73a2);
   background: -moz-linear-gradient(top, #4d8ac1, #3f73a2);
 }
+
+#flow {
+  .node {
+    .flow-start {
+      font-size: 2em;
+      margin-top: -1.5em;
+      width: auto;
+      min-width: 170px;
+      padding: 10px 15px;
+      background-color: palegreen;
+      position: absolute;
+      text-align: center;
+      color: blue;
+    }
+  }
+}

--- a/customizations/engage/static/brands/engage/less/style.less
+++ b/customizations/engage/static/brands/engage/less/style.less
@@ -68,11 +68,11 @@ a.logo {
 #flow {
   .node {
     .flow-start {
-      font-size: 2em;
-      margin-top: -1.5em;
+      font-size: 1.4em;
+      margin-top: -2em;
       width: auto;
       min-width: 170px;
-      padding: 10px 15px;
+      padding: 6px 15px;
       background-color: palegreen;
       position: absolute;
       text-align: center;

--- a/customizations/engage/static/brands/engage/less/style.less
+++ b/customizations/engage/static/brands/engage/less/style.less
@@ -73,10 +73,11 @@ a.logo {
       width: auto;
       min-width: 170px;
       padding: 6px 15px;
-      background-color: palegreen;
+      background-color: yellowgreen;
       position: absolute;
       text-align: center;
-      color: blue;
+      color: royalblue;
+      font-weight: bolder;
     }
   }
 }


### PR DESCRIPTION
CSS modified so the `Flow Start` text is ~much more noticeable~ a bit more noticeable
![Screen Shot 2020-01-28 at 10 35 15](https://user-images.githubusercontent.com/1625533/73278815-28a75980-41ba-11ea-9cc6-78b968719888.png)



IGNORE BELOW, IT WAS ORIG STYLING BEFORE VOTE CHANGED IT (kept for posterity)
![Screen Shot 2020-01-23 at 14 56 28](https://user-images.githubusercontent.com/1625533/73018960-a0f3d080-3df0-11ea-8253-cfa32e762a49.png)
