### PR TITLE
Ensure the defined SuperAdmin account for Engage exists

### DIFF
--- a/Dockerfile-engage
+++ b/Dockerfile-engage
@@ -102,3 +102,6 @@ LABEL org.label-schema.name="Engage" \
       org.label-schema.schema-version="1.0"
 
 CMD ["/startup.sh"]
+
+COPY stack/startup.py /rapidpro/
+

--- a/Dockerfile-generic
+++ b/Dockerfile-generic
@@ -99,3 +99,5 @@ LABEL org.label-schema.name="Engage" \
       org.label-schema.schema-version="1.0"
 
 CMD ["/startup.sh"]
+
+COPY stack/startup.py /rapidpro/

--- a/stack/startup.py
+++ b/stack/startup.py
@@ -3,13 +3,33 @@ os.environ['DJANGO_SETTINGS_MODULE'] = 'temba.settings'
 import django
 django.setup()
 from django.contrib.auth.management.commands.createsuperuser import get_user_model
-if get_user_model().objects.filter(username=os.environ.get('ADMIN_NAME')): 
+from django.core.exceptions import ObjectDoesNotExist
+from temba.orgs.models import Org
+
+try:
+    superuser = get_user_model().objects.get(username=os.getenv('ADMIN_EMAIL'))
     print('Super user already exists. SKIPPING.')
-elif os.environ.get('ADMIN_NAME') and os.environ.get('ADMIN_EMAIL') and os.environ.get('ADMIN_PSWD'):
-    print('Creating super user...')
-    get_user_model()._default_manager.db_manager('default').create_superuser(
-            username=os.environ.get('ADMIN_NAME'),
-            email=os.environ.get('ADMIN_EMAIL'),
-            password=os.environ.get('ADMIN_PSWD')
+except ObjectDoesNotExist:
+    if os.getenv('ADMIN_NAME') and os.getenv('ADMIN_EMAIL') and os.getenv('ADMIN_PSWD') and os.getenv('ADMIN_ORG'):
+        print('Creating super user...')
+        superuser = get_user_model()._default_manager.db_manager('default').create_superuser(
+            username=os.getenv('ADMIN_EMAIL'),
+            email=os.getenv('ADMIN_EMAIL'),
+            first_name=os.getenv('ADMIN_NAME'),
+            password=os.getenv('ADMIN_PSWD')
+        )
+        print('Super user created.')
+    
+if Org.objects.filter(name=os.getenv('ADMIN_ORG')):
+    print('Admin org already exists. SKIPPING.')
+elif superuser and os.getenv('ADMIN_ORG'):
+    print('Creating admin org...')
+    org = Org.objects.create(
+        name=os.getenv('ADMIN_ORG'),
+        timezone='UTC',
+        created_by=superuser,
+        modified_by=superuser
     )
-    print('Super user created.')
+    org.administrators.add(superuser)
+    print('Admin org created.')
+

--- a/stack/startup.py
+++ b/stack/startup.py
@@ -1,0 +1,15 @@
+import os
+os.environ['DJANGO_SETTINGS_MODULE'] = 'temba.settings'
+import django
+django.setup()
+from django.contrib.auth.management.commands.createsuperuser import get_user_model
+if get_user_model().objects.filter(username=os.environ.get('ADMIN_NAME')): 
+    print('Super user already exists. SKIPPING.')
+elif os.environ.get('ADMIN_NAME') and os.environ.get('ADMIN_EMAIL') and os.environ.get('ADMIN_PSWD'):
+    print('Creating super user...')
+    get_user_model()._default_manager.db_manager('default').create_superuser(
+            username=os.environ.get('ADMIN_NAME'),
+            email=os.environ.get('ADMIN_EMAIL'),
+            password=os.environ.get('ADMIN_PSWD')
+    )
+    print('Super user created.')

--- a/stack/startup.sh
+++ b/stack/startup.sh
@@ -1,17 +1,17 @@
 #!/bin/sh
 set -ex # fail on any error & print commands as they're run
-if [ "x$MANAGEPY_COLLECTSTATIC" = "xon" ]; then
+echo 'MANAGEPY_COLLECTSTATIC?'; if [ "x$MANAGEPY_COLLECTSTATIC" = "xon" ]; then
 	mkdir -p /rapidpro/static/sitestatic
 	cp -fr /rapidpro/static/brands /rapidpro/static/sitestatic/brands
 	/venv/bin/python manage.py collectstatic --noinput --no-post-process
 fi
-if [ "x$CLEAR_COMPRESSOR_CACHE" = "xon" ]; then
+echo 'CLEAR_COMPRESSOR_CACHE?'; if [ "x$CLEAR_COMPRESSOR_CACHE" = "xon" ]; then
 	/venv/bin/python clear-compressor-cache.py
 fi
-if [ "x$MANAGEPY_COMPRESS" = "xon" ]; then
+echo 'MANAGEPY_COMPRESS?'; if [ "x$MANAGEPY_COMPRESS" = "xon" ]; then
 	/venv/bin/python manage.py compress --extension=".haml" --force -v0
 fi
-if [ "x$MANAGEPY_INIT_DB" = "xon" ]; then
+echo 'MANAGEPY_INIT_DB?'; if [ "x$MANAGEPY_INIT_DB" = "xon" ]; then
 	set +x  # make sure the password isn't echoed to stdout
 	echo "*:*:*:*:$(echo \"$DATABASE_URL\" | cut -d'@' -f1 | cut -d':' -f3)" > $HOME/.pgpass
 	set -x
@@ -19,19 +19,21 @@ if [ "x$MANAGEPY_INIT_DB" = "xon" ]; then
 	/venv/bin/python manage.py dbshell < init_db.sql
 	rm $HOME/.pgpass
 fi
-if [ "x$MANAGEPY_MIGRATE" = "xon" ]; then
+echo 'MANAGEPY_MIGRATE?'; if [ "x$MANAGEPY_MIGRATE" = "xon" ]; then
 	/venv/bin/python manage.py migrate
 fi
-if [ "x$MANAGEPY_IMPORT_GEOJSON" = "xon" ]; then
+echo 'MANAGEPY_IMPORT_GEOJSON?'; if [ "x$MANAGEPY_IMPORT_GEOJSON" = "xon" ]; then
 	echo "Downloading geojson for relation_ids $OSM_RELATION_IDS"
 	/venv/bin/python manage.py download_geojson $OSM_RELATION_IDS
 	/venv/bin/python manage.py import_geojson ./geojson/*.json
 	echo "Imported geojson for relation_ids $OSM_RELATION_IDS"
 fi
 
+echo 'run celery or rapidpro?';
 TYPE=${1:-rapidpro}
 if [ "$TYPE" = "celery" ]; then
 	$CELERY_CMD
 elif [ "$TYPE" = "rapidpro" ]; then
+	/venv/bin/python /rapidpro/startup.py
 	$STARTUP_CMD
 fi


### PR DESCRIPTION
Whenever an Engage container is started, a quick check is performed to see if the SuperAdmin account that is defined via ADMIN_NAME, ADMIN_EMAIL, and ADMIN_PSWD env vars exists and creates it if not.

Echos to help debug logs have also been added to the startup script so the "if 'xon' then" lines have context on what is being compared.

Testing:  build this container and start it with a fresh stack and empty volumes.  once the container stands itself up, try to login with the superadmin account info.  You should log right in.