### PR TITLE
Adding android type, SMS setting for PostMaster

### DIFF
--- a/settings-engage.py
+++ b/settings-engage.py
@@ -18,7 +18,8 @@ AWS_QUERYSTRING_EXPIRE = '157784630'
 SUB_DIR = env('SUB_DIR', required=False) 
 
 #Use CHAT_MODE_CHOICES to configure the chatmodes that are available to the Postmaster channel
-CHAT_MODE_CHOICES = (("WA", _("WhatsApp")), ("TG", _("Telegram")), ("SMS", _("SMS")))
+CHAT_MODE_CHOICES = (("WA", _("WhatsApp")), ("TG", _("Telegram")),  ("LIN", _("LINE")), ("SIG", _("SIGNAL")),
+                     ("SMS", _("SMS")))
 
 if SUB_DIR is not None and len(SUB_DIR) > 0:
     MEDIA_URL = "{}{}".format(SUB_DIR, MEDIA_URL)
@@ -246,6 +247,7 @@ CHANNEL_TYPES = [
     "temba.channels.types.wechat.WeChatType",
     "temba.channels.types.yo.YoType",
     "temba.channels.types.zenvia.ZenviaType",
+    "temba.channels.types.android.AndroidType",
 ]
 
 # how many sequential contacts on import triggers suspension

--- a/settings-generic.py
+++ b/settings-generic.py
@@ -18,7 +18,8 @@ AWS_QUERYSTRING_EXPIRE = '157784630'
 SUB_DIR = env('SUB_DIR', required=False) 
 
 #Use CHAT_MODE_CHOICES to configure the chatmodes that are available to the Postmaster channel
-CHAT_MODE_CHOICES = (("WA", _("WhatsApp")), ("TG", _("Telegram")), ("SMS", _("SMS")))
+CHAT_MODE_CHOICES = (("WA", _("WhatsApp")), ("TG", _("Telegram")),  ("LIN", _("LINE")), ("SIG", _("SIGNAL")),
+                     ("SMS", _("SMS")))
 
 if SUB_DIR is not None and len(SUB_DIR) > 0:
     MEDIA_URL = "{}{}".format(SUB_DIR, MEDIA_URL)
@@ -244,6 +245,7 @@ CHANNEL_TYPES = [
     "temba.channels.types.wechat.WeChatType",
     "temba.channels.types.yo.YoType",
     "temba.channels.types.zenvia.ZenviaType",
+    "temba.channels.types.android.AndroidType",
 ]
 
 # how many sequential contacts on import triggers suspension

--- a/settings.py
+++ b/settings.py
@@ -18,7 +18,8 @@ AWS_QUERYSTRING_EXPIRE = '157784630'
 SUB_DIR = env('SUB_DIR', required=False) 
 
 #Use CHAT_MODE_CHOICES to configure the chatmodes that are available to the Postmaster channel
-CHAT_MODE_CHOICES = (("WA", _("WhatsApp")), ("TG", _("Telegram")), ("SMS", _("SMS")))
+CHAT_MODE_CHOICES = (("WA", _("WhatsApp")), ("TG", _("Telegram")),  ("LIN", _("LINE")), ("SIG", _("SIGNAL")),
+                     ("SMS", _("SMS")))
 
 if SUB_DIR is not None and len(SUB_DIR) > 0:
     MEDIA_URL = "{}{}".format(SUB_DIR, MEDIA_URL)
@@ -240,6 +241,7 @@ CHANNEL_TYPES = [
     "temba.channels.types.wechat.WeChatType",
     "temba.channels.types.yo.YoType",
     "temba.channels.types.zenvia.ZenviaType",
+    "temba.channels.types.android.AndroidType",
 ]
 
 # how many sequential contacts on import triggers suspension


### PR DESCRIPTION
# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee

P4-1434 - settings to support the latest upstream merge from Nyaruka.

## Summary
New Android channel type setting added from upstream. Added SMS to Postmaster chat_modes.

#### Release Note
A new android channel type and additional post master chat modes added.

#### Breaking Changes
Engage 4.0.2 required. Incompatible with Engage versions 4.0.1 and lower. 

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

*Steps to test your application for someone not familiar with it.* Required.

1. Do this: `$ run-this.sh`
2. Look for this.
3. Clean up with this command
