### PR TITLE
P4-1516 - Use TEL scheme for sms postmaster channels

### DIFF
--- a/settings-engage.py
+++ b/settings-engage.py
@@ -19,7 +19,7 @@ SUB_DIR = env('SUB_DIR', required=False)
 
 #Use CHAT_MODE_CHOICES to configure the chatmodes that are available to the Postmaster channel
 CHAT_MODE_CHOICES = (("WA", _("WhatsApp")), ("TG", _("Telegram")),  ("LIN", _("LINE")), ("SIG", _("SIGNAL")),
-                     ("SMS", _("SMS")))
+                     ("SMS", _("TEL")))
 POST_OFFICE_QR_URL = env('POST_OFFICE_QR_URL', 'https://localhost:8088/postoffice/relayer/claim')
 POST_OFFICE_API_KEY = env('POST_OFFICE_API_KEY', 'abc123')
 

--- a/settings-generic.py
+++ b/settings-generic.py
@@ -19,7 +19,7 @@ SUB_DIR = env('SUB_DIR', required=False)
 
 #Use CHAT_MODE_CHOICES to configure the chatmodes that are available to the Postmaster channel
 CHAT_MODE_CHOICES = (("WA", _("WhatsApp")), ("TG", _("Telegram")),  ("LIN", _("LINE")), ("SIG", _("SIGNAL")),
-                     ("SMS", _("SMS")))
+                     ("SMS", _("TEL")))
 POST_OFFICE_QR_URL = env('POST_OFFICE_QR_URL', 'https://localhost:8088/postoffice/relayer/claim')
 POST_OFFICE_API_KEY = env('POST_OFFICE_API_KEY', 'abc123')
 

--- a/settings.py
+++ b/settings.py
@@ -19,7 +19,7 @@ SUB_DIR = env('SUB_DIR', required=False)
 
 #Use CHAT_MODE_CHOICES to configure the chatmodes that are available to the Postmaster channel
 CHAT_MODE_CHOICES = (("WA", _("WhatsApp")), ("TG", _("Telegram")),  ("LIN", _("LINE")), ("SIG", _("SIGNAL")),
-                     ("SMS", _("SMS")))
+                     ("SMS", _("TEL")))
 POST_OFFICE_QR_URL = env('POST_OFFICE_QR_URL', 'https://localhost:8088/postoffice/relayer/claim')
 POST_OFFICE_API_KEY = env('POST_OFFICE_API_KEY', 'abc123')
 


### PR DESCRIPTION
# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

## Summary
Postmaster SMS channels will now use the built-in TEL scheme. 

#### Release Note
None

#### Breaking Changes
None

## Quality Assurance

You have gathered the following items:
- [x] This PR is tagged with a Release Milestone

## Testing and Verification

1. Deploy a full engage stack via docker-compose
2. Add a postmaster SMS channel and confirm the scheme is listed as TEL