### PR TITLE
P4-1658 - Add VK mode to postmaster channel

### DIFF
--- a/settings-engage.py
+++ b/settings-engage.py
@@ -19,8 +19,8 @@ SUB_DIR = env('SUB_DIR', required=False)
 
 #Use CHAT_MODE_CHOICES to configure the chatmodes that are available to the Postmaster channel
 CHAT_MODE_CHOICES = (("WA", _("WhatsApp")), ("TG", _("Telegram")),  ("LIN", _("LINE")), ("SIG", _("SIGNAL")),
-                     ("SMS", _("TEL")))
-POST_OFFICE_QR_URL = env('POST_OFFICE_QR_URL', 'https://localhost:8088/postoffice/relayer/claim')
+                     ("SMS", _("TEL")), ("VK", _("VK")))
+POST_OFFICE_QR_URL = env('POST_OFFICE_QR_URL', 'https://localhost:8088/postoffice/engage/claim')
 POST_OFFICE_API_KEY = env('POST_OFFICE_API_KEY', 'abc123')
 
 if SUB_DIR is not None and len(SUB_DIR) > 0:

--- a/settings-generic.py
+++ b/settings-generic.py
@@ -19,8 +19,8 @@ SUB_DIR = env('SUB_DIR', required=False)
 
 #Use CHAT_MODE_CHOICES to configure the chatmodes that are available to the Postmaster channel
 CHAT_MODE_CHOICES = (("WA", _("WhatsApp")), ("TG", _("Telegram")),  ("LIN", _("LINE")), ("SIG", _("SIGNAL")),
-                     ("SMS", _("TEL")))
-POST_OFFICE_QR_URL = env('POST_OFFICE_QR_URL', 'https://localhost:8088/postoffice/relayer/claim')
+                     ("SMS", _("TEL")), ("VK", _("VK")))
+POST_OFFICE_QR_URL = env('POST_OFFICE_QR_URL', 'https://localhost:8088/postoffice/engage/claim')
 POST_OFFICE_API_KEY = env('POST_OFFICE_API_KEY', 'abc123')
 
 if SUB_DIR is not None and len(SUB_DIR) > 0:

--- a/settings.py
+++ b/settings.py
@@ -19,8 +19,8 @@ SUB_DIR = env('SUB_DIR', required=False)
 
 #Use CHAT_MODE_CHOICES to configure the chatmodes that are available to the Postmaster channel
 CHAT_MODE_CHOICES = (("WA", _("WhatsApp")), ("TG", _("Telegram")),  ("LIN", _("LINE")), ("SIG", _("SIGNAL")),
-                     ("SMS", _("TEL")))
-POST_OFFICE_QR_URL = env('POST_OFFICE_QR_URL', 'https://localhost:8088/postoffice/relayer/claim')
+                     ("SMS", _("TEL")), ("VK", _("VK")))
+POST_OFFICE_QR_URL = env('POST_OFFICE_QR_URL', 'https://localhost:8088/postoffice/engage/claim')
 POST_OFFICE_API_KEY = env('POST_OFFICE_API_KEY', 'abc123')
 
 if SUB_DIR is not None and len(SUB_DIR) > 0:


### PR DESCRIPTION
# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

## Summary
Added Postmaster VK channel and scheme. Fixed default config for postoffice claim url.

#### Release Note
Added Postmaster VK support to engage

#### Breaking Changes
None.

## Quality Assurance

You have gathered the following items:
- [x] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

See instructions for the companion [rapidpro pr](https://github.com/istresearch/rapidpro/pull/110).
