### PR TITLE
P4-1736 - Engage - Configurable Label Count Limit

### DIFF
--- a/settings-engage.py
+++ b/settings-engage.py
@@ -17,6 +17,8 @@ from django.urls import base
 AWS_QUERYSTRING_EXPIRE = '157784630'
 SUB_DIR = env('SUB_DIR', required=False) 
 
+MAX_ORG_LABELS = env('MAX_ORG_LABELS', 500)
+
 #Use CHAT_MODE_CHOICES to configure the chatmodes that are available to the Postmaster channel
 CHAT_MODE_CHOICES = (("WA", _("WhatsApp")), ("TG", _("Telegram")),  ("LIN", _("LINE")), ("SIG", _("SIGNAL")),
                      ("SMS", _("TEL")), ("VK", _("VK")))

--- a/settings-engage.py
+++ b/settings-engage.py
@@ -17,7 +17,7 @@ from django.urls import base
 AWS_QUERYSTRING_EXPIRE = '157784630'
 SUB_DIR = env('SUB_DIR', required=False) 
 
-MAX_ORG_LABELS = env('MAX_ORG_LABELS', 500)
+MAX_ORG_LABELS = int(env('MAX_ORG_LABELS', 500))
 
 #Use CHAT_MODE_CHOICES to configure the chatmodes that are available to the Postmaster channel
 CHAT_MODE_CHOICES = (("WA", _("WhatsApp")), ("TG", _("Telegram")),  ("LIN", _("LINE")), ("SIG", _("SIGNAL")),

--- a/settings-generic.py
+++ b/settings-generic.py
@@ -17,6 +17,8 @@ from django.urls import base
 AWS_QUERYSTRING_EXPIRE = '157784630'
 SUB_DIR = env('SUB_DIR', required=False) 
 
+MAX_ORG_LABELS = env('MAX_ORG_LABELS', 500)
+
 #Use CHAT_MODE_CHOICES to configure the chatmodes that are available to the Postmaster channel
 CHAT_MODE_CHOICES = (("WA", _("WhatsApp")), ("TG", _("Telegram")),  ("LIN", _("LINE")), ("SIG", _("SIGNAL")),
                      ("SMS", _("TEL")), ("VK", _("VK")))

--- a/settings-generic.py
+++ b/settings-generic.py
@@ -17,7 +17,7 @@ from django.urls import base
 AWS_QUERYSTRING_EXPIRE = '157784630'
 SUB_DIR = env('SUB_DIR', required=False) 
 
-MAX_ORG_LABELS = env('MAX_ORG_LABELS', 500)
+MAX_ORG_LABELS = int(env('MAX_ORG_LABELS', 500))
 
 #Use CHAT_MODE_CHOICES to configure the chatmodes that are available to the Postmaster channel
 CHAT_MODE_CHOICES = (("WA", _("WhatsApp")), ("TG", _("Telegram")),  ("LIN", _("LINE")), ("SIG", _("SIGNAL")),

--- a/settings.py
+++ b/settings.py
@@ -17,6 +17,8 @@ from django.urls import base
 AWS_QUERYSTRING_EXPIRE = '157784630'
 SUB_DIR = env('SUB_DIR', required=False) 
 
+MAX_ORG_LABELS = env('MAX_ORG_LABELS', 500)
+
 #Use CHAT_MODE_CHOICES to configure the chatmodes that are available to the Postmaster channel
 CHAT_MODE_CHOICES = (("WA", _("WhatsApp")), ("TG", _("Telegram")),  ("LIN", _("LINE")), ("SIG", _("SIGNAL")),
                      ("SMS", _("TEL")), ("VK", _("VK")))

--- a/settings.py
+++ b/settings.py
@@ -17,7 +17,7 @@ from django.urls import base
 AWS_QUERYSTRING_EXPIRE = '157784630'
 SUB_DIR = env('SUB_DIR', required=False) 
 
-MAX_ORG_LABELS = env('MAX_ORG_LABELS', 500)
+MAX_ORG_LABELS = int(env('MAX_ORG_LABELS', 500))
 
 #Use CHAT_MODE_CHOICES to configure the chatmodes that are available to the Postmaster channel
 CHAT_MODE_CHOICES = (("WA", _("WhatsApp")), ("TG", _("Telegram")),  ("LIN", _("LINE")), ("SIG", _("SIGNAL")),


### PR DESCRIPTION
# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee

P4-1736 - Turning `MAX_ORG_LABELS` into a configurable setting.

## Summary
`MAX_ORG_LABELS` is now a configurable setting.

#### Release Note
`MAX_ORG_LABELS` is now configurable via environment variable `MAX_ORG_LABELS`. The default value is coded in rp-docker/settings*.py

#### Breaking Changes
Pre 4.0.3

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

*Steps to test your application for someone not familiar with it.* Required.
1) Configure Engage using this rp-docker branch's setting.py or set the MAX_ORG_LABELS env var in p4-proxy's docker-compose. (To ease testing, use a very low value such as 2 or 3)
2) Navigate to the messages screen and create more than the "MAX_ORG_LABELS" amount of labels.

If you have reached the maximum amount of labels you will see this message:
<img width="587" alt="Screen Shot 2020-07-28 at 2 21 54 PM" src="https://user-images.githubusercontent.com/6886738/88706753-46109e00-d0df-11ea-9230-a276af3719fe.png">

Now change the MAX_ORG_LABELS value to a high number and retry steps 1 and 2. This time you should not see an error.


