### PR TITLE
P4-856 - Adjust Engage to use non-root container user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,15 @@
 # python:2.7-alpine with GEOS, GDAL, and Proj installed (built as a separate image
 # because it takes a long time to build)
+
 ARG VERSION_TAG
 
 FROM istresearch/p4-engage:code-${VERSION_TAG}
- 
+
+RUN addgroup engage
+RUN adduser -D -S -s /bin/false -u 1717 engage -g engage
+
+USER root
+
 ARG RAPIDPRO_VERSION
 ENV PIP_RETRIES=120 \
     PIP_TIMEOUT=400 \
@@ -97,4 +103,7 @@ LABEL org.label-schema.name="RapidPro" \
       org.label-schema.version=$RAPIDPRO_VERSION \
       org.label-schema.schema-version="1.0"
 
+RUN chown -R engage /rapidpro
+RUN chgrp -R engage /rapidpro
+USER engage
 CMD ["/startup.sh"]

--- a/Dockerfile-engage
+++ b/Dockerfile-engage
@@ -3,7 +3,12 @@
 ARG VERSION_TAG
 
 FROM istresearch/p4-engage:code-${VERSION_TAG}
- 
+
+RUN addgroup engage
+RUN adduser -D -S -s /bin/false -u 1717 engage -g engage
+
+USER root
+
 ARG RAPIDPRO_VERSION
 ENV PIP_RETRIES=120 \
     PIP_TIMEOUT=400 \
@@ -101,6 +106,9 @@ LABEL org.label-schema.name="Engage" \
       org.label-schema.version=$VERSION_TAG \
       org.label-schema.schema-version="1.0"
 
+RUN chown -R engage /rapidpro
+RUN chgrp -R engage /rapidpro
+USER engage
 CMD ["/startup.sh"]
 
 COPY stack/startup.py /rapidpro/

--- a/Dockerfile-generic
+++ b/Dockerfile-generic
@@ -3,7 +3,12 @@
 ARG VERSION_TAG
 
 FROM istresearch/p4-engage:code-${VERSION_TAG}
- 
+
+RUN addgroup engage
+RUN adduser -D -S -s /bin/false -u 1717 engage -g engage
+
+USER root
+
 ARG RAPIDPRO_VERSION
 ENV PIP_RETRIES=120 \
     PIP_TIMEOUT=400 \
@@ -98,6 +103,9 @@ LABEL org.label-schema.name="Engage" \
       org.label-schema.version=$VERSION_TAG \
       org.label-schema.schema-version="1.0"
 
+RUN chown -R engage /rapidpro
+RUN chgrp -R engage /rapidpro
+USER engage
 CMD ["/startup.sh"]
 
 COPY stack/startup.py /rapidpro/


### PR DESCRIPTION
# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee
P4-856 - Adjust Engage to use non-root container user

## Summary
Engage and UWSGI workers should run under a non-root user.

#### Release Note
Engage and UWSGI workers should run under a non-root user.

#### Breaking Changes
None.

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

*Steps to test your application for someone not familiar with it.* Required.

1. build the local image from this branch: `docker build --no-cache --build-arg VERSION_TAG=local-dev -t istresearch/p4-engage:local-dev -f Dockerfile .`
2. In the p4-proxy repo modify the docker-compose.yml file so that the engage service uses the newly created local image:
```
services:
  engage:
    image: istresearch/p4-engage:local-dev
    depends_on:
      - redis
      - postgresql
    ports:
      - '${HOSTPORT}:8000'
```
3. Run engage from the p4-proxy directory using `ISTs-MacBook-Pro:p4-proxy istresearch$ docker-compose up -d`

4. from the rapidpro-docker directory open a shell to the running engage container: `ISTs-MacBook-Pro:rp-docker istresearch$ docker-compose exec engage sh`

5. Verify that you are logged in as the new non-root engage user:
```
/rapidpro $ whoami
engage
```
6. Verify that uwsgi workers are running as the non-root engage user:
```
/rapidpro $ ps aux
PID   USER     TIME  COMMAND
    1 engage    0:00 {startup.sh} /bin/sh /startup.sh
   27 engage    0:04 /venv/bin/uwsgi --http-auto-chunked --http-keepalive
   33 engage    0:00 /venv/bin/uwsgi --http-auto-chunked --http-keepalive
   34 engage    0:00 /venv/bin/uwsgi --http-auto-chunked --http-keepalive
   35 engage    0:00 /venv/bin/uwsgi --http-auto-chunked --http-keepalive
   36 engage    0:00 /venv/bin/uwsgi --http-auto-chunked --http-keepalive
   37 engage    0:00 /venv/bin/uwsgi --http-auto-chunked --http-keepalive
   38 engage    0:00 /venv/bin/uwsgi --http-auto-chunked --http-keepalive
   39 engage    0:00 /venv/bin/uwsgi --http-auto-chunked --http-keepalive
   40 engage    0:00 /venv/bin/uwsgi --http-auto-chunked --http-keepalive
   41 engage    0:00 /venv/bin/uwsgi --http-auto-chunked --http-keepalive
   42 engage    0:00 /venv/bin/uwsgi --http-auto-chunked --http-keepalive
   43 engage    0:00 /venv/bin/uwsgi --http-auto-chunked --http-keepalive
   44 engage    0:01 /venv/bin/uwsgi --http-auto-chunked --http-keepalive
   45 engage    0:00 /venv/bin/uwsgi --http-auto-chunked --http-keepalive
   56 engage    0:00 sh
   62 engage    0:00 ps aux
```

7. Verify that /rapidpro and all subdirectories are owned by the non-root engage user and engage group:
```
/rapidpro $ ls -alh /rapidpro/
total 856
drwxr-xr-x    1 engage   engage      4.0K Aug  5 16:39 .
drwxr-xr-x    1 root     root        4.0K Aug  5 18:03 ..
-rw-r--r--    1 engage   engage      8.0K Aug  4 15:17 .DS_Store
-rw-r--r--    1 engage   engage        36 Aug  4 15:17 .babelrc
...
drwxr-xr-x    1 engage   engage     12.0K Aug  4 15:17 sitestatic.bak
drwxr-xr-x    1 engage   engage      4.0K Aug  4 15:17 src
drwxr-xr-x    1 engage   engage      4.0K Aug  4 15:17 static
drwxr-xr-x    1 engage   engage      4.0K Aug  5 16:39 temba
drwxr-xr-x    1 engage   engage      4.0K Aug  5 16:39 templates
drwxr-xr-x    1 engage   engage      4.0K Aug  4 15:17 test-data
```

8. Verify that the engage user's UID is not 1001 and that it is not a member of any system or root groups:
```
/rapidpro $ cat /etc/passwd
root:x:0:0:root:/root:/bin/ash
bin:x:1:1:bin:/bin:/sbin/nologin
daemon:x:2:2:daemon:/sbin:/sbin/nologin
adm:x:3:4:adm:/var/adm:/sbin/nologin
lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin
sync:x:5:0:sync:/sbin:/bin/sync
shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown
halt:x:7:0:halt:/sbin:/sbin/halt
mail:x:8:12:mail:/var/spool/mail:/sbin/nologin
news:x:9:13:news:/usr/lib/news:/sbin/nologin
uucp:x:10:14:uucp:/var/spool/uucppublic:/sbin/nologin
operator:x:11:0:operator:/root:/bin/sh
man:x:13:15:man:/usr/man:/sbin/nologin
postmaster:x:14:12:postmaster:/var/spool/mail:/sbin/nologin
cron:x:16:16:cron:/var/spool/cron:/sbin/nologin
ftp:x:21:21::/var/lib/ftp:/sbin/nologin
sshd:x:22:22:sshd:/dev/null:/sbin/nologin
at:x:25:25:at:/var/spool/cron/atjobs:/sbin/nologin
squid:x:31:31:Squid:/var/cache/squid:/sbin/nologin
xfs:x:33:33:X Font Server:/etc/X11/fs:/sbin/nologin
games:x:35:35:games:/usr/games:/sbin/nologin
postgres:x:70:70::/var/lib/postgresql:/bin/sh
cyrus:x:85:12::/usr/cyrus:/sbin/nologin
vpopmail:x:89:89::/var/vpopmail:/sbin/nologin
ntp:x:123:123:NTP:/var/empty:/sbin/nologin
smmsp:x:209:209:smmsp:/var/spool/mqueue:/sbin/nologin
guest:x:405:100:guest:/dev/null:/sbin/nologin
nobody:x:65534:65534:nobody:/:/sbin/nologin
engage:x:1717:65533:engage:/home/engage:/bin/false
```
9. With Engage running, navigate to Engage using your web browser and ensure that requests receive valid responses and that pages are being rendered.