### PR TITLE
P4-2002 - Engage - Set default TPS values as a configurable value in …

### DIFF
--- a/settings-engage.py
+++ b/settings-engage.py
@@ -17,6 +17,8 @@ from django.urls import base
 AWS_QUERYSTRING_EXPIRE = '157784630'
 SUB_DIR = env('SUB_DIR', required=False) 
 COURIER_URL = env('COURIER_URL', 'http://localhost:8080')
+DEFAULT_TPS = env('DEFAULT_TPS', 10)    # Default Transactions Per Second for newly create Channels.
+MAX_TPS = env('MAX_TPS', 50)            # Max configurable Transactions Per Second for newly Created Channels and Updated Channels.
 
 MAX_ORG_LABELS = int(env('MAX_ORG_LABELS', 500))
 

--- a/settings-generic.py
+++ b/settings-generic.py
@@ -17,6 +17,8 @@ from django.urls import base
 AWS_QUERYSTRING_EXPIRE = '157784630'
 SUB_DIR = env('SUB_DIR', required=False) 
 COURIER_URL = env('COURIER_URL', 'http://localhost:8080')
+DEFAULT_TPS = env('DEFAULT_TPS', 10)    # Default Transactions Per Second for newly create Channels.
+MAX_TPS = env('MAX_TPS', 50)            # Max configurable Transactions Per Second for newly Created Channels and Updated Channels.
 
 MAX_ORG_LABELS = int(env('MAX_ORG_LABELS', 500))
 

--- a/settings.py
+++ b/settings.py
@@ -17,6 +17,8 @@ from django.urls import base
 AWS_QUERYSTRING_EXPIRE = '157784630'
 SUB_DIR = env('SUB_DIR', required=False) 
 COURIER_URL = env('COURIER_URL', 'http://localhost:8080')
+DEFAULT_TPS = env('DEFAULT_TPS', 10)    # Default Transactions Per Second for newly create Channels.
+MAX_TPS = env('MAX_TPS', 50)            # Max configurable Transactions Per Second for newly Created Channels and Updated Channels.
 
 MAX_ORG_LABELS = int(env('MAX_ORG_LABELS', 500))
 


### PR DESCRIPTION
…settings.py

# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee

Two new settings have been added (DEFAULT_TPS and MAX_TPS) with defaults of 10 and 50 respectively.
## Summary
Two new settings have been added (DEFAULT_TPS and MAX_TPS) with defaults of 10 and 50 respectively.

#### Release Note
<Concise sentence describing change>Required.

#### Breaking Changes
<Description for Techops of how to handle changes, migrations, updates>None.

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

*Steps to test your application for someone not familiar with it.* Required.

1. Do this: `$ run-this.sh`
2. Look for this.
3. Clean up with this command
