### PR TITLE
P4-2303 - Adjust dockerfiles to run npm install as user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,6 +78,13 @@ RUN cd /rapidpro && npm install npm@latest
 # Install `libmagic` (needed since rapidpro v3.0.64)
 RUN apk add --no-cache postgresql-client libmagic
 
+RUN chown -R engage /rapidpro
+RUN chgrp -R engage /rapidpro
+USER engage:engage
+
+# Run this after switching from root so prepare will run on packages
+RUN npm install
+
 ENV UWSGI_VIRTUALENV=/venv UWSGI_WSGI_FILE=temba/wsgi.py UWSGI_HTTP=:8000 UWSGI_MASTER=1 UWSGI_WORKERS=8 UWSGI_HARAKIRI=20
 # Enable HTTP 1.1 Keep Alive options for uWSGI (http-auto-chunked needed when ConditionalGetMiddleware not installed)
 # These options don't appear to be configurable via environment variables, so pass them in here instead
@@ -101,12 +108,5 @@ LABEL org.label-schema.name="RapidPro" \
       org.label-schema.vendor="Nyaruka, UNICEF, and individual contributors." \
       org.label-schema.version=$RAPIDPRO_VERSION \
       org.label-schema.schema-version="1.0"
-
-RUN chown -R engage /rapidpro
-RUN chgrp -R engage /rapidpro
-USER engage:engage
-
-# Run this after switching from root so prepare will run on packages
-RUN npm install
 
 CMD ["/startup.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,8 +78,7 @@ RUN cd /rapidpro && npm install npm@latest
 # Install `libmagic` (needed since rapidpro v3.0.64)
 RUN apk add --no-cache postgresql-client libmagic
 
-RUN chown -R engage /rapidpro
-RUN chgrp -R engage /rapidpro
+RUN chown -R engage:engage /rapidpro
 USER engage:engage
 
 # Run this after switching from root so prepare will run on packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,8 +72,7 @@ RUN LIBRARY_PATH=/lib:/usr/lib /bin/sh -c "/venv/bin/pip install setuptools==33.
     && apk --no-cache add --virtual .python-rundeps $runDeps \
     && apk del .build-deps && rm -rf /var/cache/apk/*
 
-# TODO should this be in startup.sh?
-RUN cd /rapidpro && npm install npm@latest && npm install 
+RUN cd /rapidpro && npm install npm@latest
 
 # Install `psql` command (needed for `manage.py dbshell` in stack/init_db.sql)
 # Install `libmagic` (needed since rapidpro v3.0.64)
@@ -105,5 +104,9 @@ LABEL org.label-schema.name="RapidPro" \
 
 RUN chown -R engage /rapidpro
 RUN chgrp -R engage /rapidpro
-USER engage
+USER engage:engage
+
+# Run this after switching from root so prepare will run on packages
+RUN npm install
+
 CMD ["/startup.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ENV PIP_RETRIES=120 \
 # TODO determine if a more recent version of Node is needed
 # TODO extract openssl and tar to their own upgrade/install line
 RUN set -ex \
-  && apk add --no-cache nodejs-lts nodejs-npm openssl tar \
+  && apk add --no-cache git nodejs-lts nodejs-npm openssl tar \
   && npm install -g coffee-script less bower
 
 WORKDIR /rapidpro

--- a/Dockerfile-engage
+++ b/Dockerfile-engage
@@ -19,7 +19,7 @@ ENV PIP_RETRIES=120 \
 # TODO determine if a more recent version of Node is needed
 # TODO extract openssl and tar to their own upgrade/install line
 RUN set -ex \
-  && apk add --no-cache nodejs-lts nodejs-npm openssl tar \
+  && apk add --no-cache git nodejs-lts nodejs-npm openssl tar \
   && npm install -g coffee-script less bower
 
 WORKDIR /rapidpro

--- a/Dockerfile-engage
+++ b/Dockerfile-engage
@@ -77,6 +77,13 @@ RUN cd /rapidpro && npm install npm@latest
 # Install `libmagic` (needed since rapidpro v3.0.64)
 RUN apk add --no-cache postgresql-client libmagic
 
+RUN chown -R engage /rapidpro
+RUN chgrp -R engage /rapidpro
+USER engage:engage
+
+# Run this after switching from root so prepare will run on packages
+RUN npm install
+
 ENV UWSGI_VIRTUALENV=/venv UWSGI_WSGI_FILE=temba/wsgi.py UWSGI_HTTP=:8000 UWSGI_MASTER=1 UWSGI_WORKERS=8 UWSGI_HARAKIRI=20
 # Enable HTTP 1.1 Keep Alive options for uWSGI (http-auto-chunked needed when ConditionalGetMiddleware not installed)
 # These options don't appear to be configurable via environment variables, so pass them in here instead
@@ -104,13 +111,6 @@ LABEL org.label-schema.name="Engage" \
       org.label-schema.vendor="IST Research" \
       org.label-schema.version=$VERSION_TAG \
       org.label-schema.schema-version="1.0"
-
-RUN chown -R engage /rapidpro
-RUN chgrp -R engage /rapidpro
-USER engage:engage
-
-# Run this after switching from root so prepare will run on packages
-RUN npm install
 
 CMD ["/startup.sh"]
 

--- a/Dockerfile-engage
+++ b/Dockerfile-engage
@@ -71,8 +71,7 @@ RUN LIBRARY_PATH=/lib:/usr/lib /bin/sh -c "/venv/bin/pip install setuptools==33.
     && apk --no-cache add --virtual .python-rundeps $runDeps \
     && apk del .build-deps && rm -rf /var/cache/apk/*
 
-# TODO should this be in startup.sh?
-RUN cd /rapidpro && npm install npm@latest && npm install
+RUN cd /rapidpro && npm install npm@latest
 
 # Install `psql` command (needed for `manage.py dbshell` in stack/init_db.sql)
 # Install `libmagic` (needed since rapidpro v3.0.64)
@@ -108,7 +107,11 @@ LABEL org.label-schema.name="Engage" \
 
 RUN chown -R engage /rapidpro
 RUN chgrp -R engage /rapidpro
-USER engage
+USER engage:engage
+
+# Run this after switching from root so prepare will run on packages
+RUN npm install
+
 CMD ["/startup.sh"]
 
 COPY stack/startup.py /rapidpro/

--- a/Dockerfile-engage
+++ b/Dockerfile-engage
@@ -77,8 +77,7 @@ RUN cd /rapidpro && npm install npm@latest
 # Install `libmagic` (needed since rapidpro v3.0.64)
 RUN apk add --no-cache postgresql-client libmagic
 
-RUN chown -R engage /rapidpro
-RUN chgrp -R engage /rapidpro
+RUN chown -R engage:engage /rapidpro
 USER engage:engage
 
 # Run this after switching from root so prepare will run on packages

--- a/Dockerfile-generic
+++ b/Dockerfile-generic
@@ -19,7 +19,7 @@ ENV PIP_RETRIES=120 \
 # TODO determine if a more recent version of Node is needed
 # TODO extract openssl and tar to their own upgrade/install line
 RUN set -ex \
-  && apk add --no-cache nodejs-lts nodejs-npm openssl tar \
+  && apk add --no-cache git nodejs-lts nodejs-npm openssl tar \
   && npm install -g coffee-script less bower
 
 WORKDIR /rapidpro

--- a/Dockerfile-generic
+++ b/Dockerfile-generic
@@ -77,8 +77,7 @@ RUN cd /rapidpro && npm install npm@latest
 # Install `libmagic` (needed since rapidpro v3.0.64)
 RUN apk add --no-cache postgresql-client libmagic
 
-RUN chown -R engage /rapidpro
-RUN chgrp -R engage /rapidpro
+RUN chown -R engage:engage /rapidpro
 USER engage:engage
 
 # Run this after switching from root so prepare will run on packages

--- a/Dockerfile-generic
+++ b/Dockerfile-generic
@@ -71,8 +71,7 @@ RUN LIBRARY_PATH=/lib:/usr/lib /bin/sh -c "/venv/bin/pip install setuptools==33.
     && apk --no-cache add --virtual .python-rundeps $runDeps \
     && apk del .build-deps && rm -rf /var/cache/apk/*
 
-# TODO should this be in startup.sh?
-RUN cd /rapidpro && npm install npm@latest && npm install
+RUN cd /rapidpro && npm install npm@latest
 
 # Install `psql` command (needed for `manage.py dbshell` in stack/init_db.sql)
 # Install `libmagic` (needed since rapidpro v3.0.64)
@@ -105,7 +104,11 @@ LABEL org.label-schema.name="Engage" \
 
 RUN chown -R engage /rapidpro
 RUN chgrp -R engage /rapidpro
-USER engage
+USER engage:engage
+
+# Run this after switching from root so prepare will run on packages
+RUN npm install
+
 CMD ["/startup.sh"]
 
 COPY stack/startup.py /rapidpro/

--- a/Dockerfile-generic
+++ b/Dockerfile-generic
@@ -77,6 +77,13 @@ RUN cd /rapidpro && npm install npm@latest
 # Install `libmagic` (needed since rapidpro v3.0.64)
 RUN apk add --no-cache postgresql-client libmagic
 
+RUN chown -R engage /rapidpro
+RUN chgrp -R engage /rapidpro
+USER engage:engage
+
+# Run this after switching from root so prepare will run on packages
+RUN npm install
+
 ENV UWSGI_VIRTUALENV=/venv UWSGI_WSGI_FILE=temba/wsgi.py UWSGI_HTTP=:8000 UWSGI_MASTER=1 UWSGI_WORKERS=8 UWSGI_HARAKIRI=20
 # Enable HTTP 1.1 Keep Alive options for uWSGI (http-auto-chunked needed when ConditionalGetMiddleware not installed)
 # These options don't appear to be configurable via environment variables, so pass them in here instead
@@ -101,13 +108,6 @@ LABEL org.label-schema.name="Engage" \
       org.label-schema.description="Enabling Global Conversations." \
       org.label-schema.version=$VERSION_TAG \
       org.label-schema.schema-version="1.0"
-
-RUN chown -R engage /rapidpro
-RUN chgrp -R engage /rapidpro
-USER engage:engage
-
-# Run this after switching from root so prepare will run on packages
-RUN npm install
 
 CMD ["/startup.sh"]
 


### PR DESCRIPTION
# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

## Summary
Running `npm install` as root inside the container was preventing `prepare` script from running for dependencies. The dockerfiles have been adjusted to run install as the `engage` user. Additionally, I combined the chown and chgrp commands into one command to help speed up the build a bit. 

#### Release Note
NPM install will now run as non-root during the docker container build.

#### Breaking Changes
None.

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

[See rapidpro test instructions](https://github.com/istresearch/rapidpro/pull/142)
